### PR TITLE
create release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Create release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Zip Folder
+      run: zip -r ${{ github.event.repository.name }}.zip ./Platforms
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: ${{ github.event.repository.name }}.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Zip Folder
-      run: zip -r ${{ github.event.repository.name }}.zip ./Platforms
+      run: zip -r ${{ github.event.repository.name }}.zip ./Platforms/_images
 
     - name: Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
this github action will automatically create a zip of just the Platforms/_images folder and attach it to the release
i think that'll make it easier to support custom image packs if everyone uses a standard release method (the spiritualized image pack is like this lol so i figure we just copy that)
